### PR TITLE
add megablocks support for linear_moe_qwen2

### DIFF
--- a/examples/linear_moe_qwen2/run_pretrain_qwen.sh
+++ b/examples/linear_moe_qwen2/run_pretrain_qwen.sh
@@ -80,7 +80,8 @@ linear_moe_options=" \
         --la-output-norm rmsnorm \
         --la-gate-fn swish \
         --layer-type-list ${LAYER_TYPE_LIST} \
-        "
+        --moe-megablocks"
+        # --moe-grouped-gemm"
 
 if [ $ENV = dsw ]; then
 export CUDA_VISIBLE_DEVICES=0,1

--- a/linear_moe/arguments.py
+++ b/linear_moe/arguments.py
@@ -326,6 +326,9 @@ def get_patch_args(parser):
 
     group.add_argument('--moe', action='store_true')
 
+    group.add_argument('--moe-megablocks', action='store_true',
+                       help='When set to True, use Megablocks for MoE layer.')
+
     group.add_argument('--moe-topk', type=int, default=1,
                        help='moe-topk')
 

--- a/linear_moe/model/qwen2/transformer_config.py
+++ b/linear_moe/model/qwen2/transformer_config.py
@@ -30,6 +30,9 @@ class Qwen2TransformerConfig(TransformerConfig):
 
     moe_layer_freq: int = None
 
+    moe_megablocks: bool = False
+    """When set to True, use Megablocks for MoE layer."""
+
     rotary_base: int = None
 
     rotary_scaling_factor: int = None
@@ -83,3 +86,9 @@ class Qwen2TransformerConfig(TransformerConfig):
     expand_v: float = 1.0
     
     layer_type_list: str = None
+
+    def __post_init__(self):
+        super().__post_init__()
+
+        if self.moe_megablocks and self.moe_grouped_gemm:
+            raise ValueError("moe_megablocks and moe_grouped_gemm cannot be both True.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,6 @@ tensorboard
 lm_dataformat
 tiktoken
 mamba-ssm
+megablocks==0.5.1  # torch<3.0,>=2.3.0
+stanford-stk==0.7.1
+git+https://github.com/fanshiqing/grouped_gemm@v1.0


### PR DESCRIPTION
## Setup

You could use the new environment with `megablocks` and `stanford-stk` installed for fast reproducing the results: `tzhu-mega-cuda121`.

Or, if you want to install the dependencies, please ensure `megablocks==0.5.1`, otherwise the environment would crash for dependency mismatch (e.g. torch, triton, etc.).

## What's New

- Support megablocks for qwen2 moe pre-training (make sure to add the `--moe-megablocks` argument in the launch script)
- Checking `grouped_gemm` (`--moe-grouped-gemm`), which is another training acceleration strategy that needs third-party support. Check out the `requirements.txt` for details.

## Speed Estimation Results

NOTICE: there are rounding errors that the precision could not be exactly aligned across different acceleration strategies.

Experiments are conducted on 2*A100.

| Strategy | Elapsed Time / Iteration (ms) |
| :- | -: |
| w/o Acceleration | 1898.4 |
| w/ Grouped GEMM | 996.2 |
| w/ MegaBlocks | 814.6 |
