### PR TITLE
Param Counts in Qwen2

### DIFF
--- a/linear_moe/model/qwen2/moe/experts.py
+++ b/linear_moe/model/qwen2/moe/experts.py
@@ -71,14 +71,14 @@ class GroupedMLP(MegatronModule):
         else:
             tp_size = parallel_state.get_tensor_model_parallel_world_size()
 
-        fc1_output_size = self.config.ffn_hidden_size * self.num_local_experts
+        fc1_output_size = self.config.moe_ffn_hidden_size * self.num_local_experts
         if config.gated_linear_unit:
             # Project to 4h. If using swiglu double the output width,
             # see https://arxiv.org/pdf/2002.05202.pdf
             fc1_output_size *= 2
         fc1_output_size_per_partition = divide(fc1_output_size, tp_size)
 
-        fc2_input_size = self.config.ffn_hidden_size * self.num_local_experts
+        fc2_input_size = self.config.moe_ffn_hidden_size * self.num_local_experts
         fc2_input_size_per_partition = divide(fc2_input_size, tp_size)
 
         # Note: The current kernel implementations of grouped_gemm

--- a/linear_moe/model/qwen2/moe/moe_layer.py
+++ b/linear_moe/model/qwen2/moe/moe_layer.py
@@ -101,7 +101,7 @@ class MoELayer(BaseMoELayer):
             mb_args = MegablocksArguments(
                 # ffn settings
                 hidden_size=self.config.hidden_size,
-                ffn_hidden_size=self.config.ffn_hidden_size,
+                ffn_hidden_size=self.config.moe_ffn_hidden_size,
                 bias=self.config.add_bias_linear,
                 return_bias=True,  # set to True for interface consistency
                 activation_fn=self.config.activation_func,


### PR DESCRIPTION
During Qwen2 pretraining with MoE layers, I noticed two potential inconsistencies that might be worth addressing:

---

1. There appears to be a difference in parameter counting between `utils.py` _(Number of parameters in transformer layers in billions...)_ and `megatron/training.py` _(number of parameters on (tensor, pipeline)...)_.

This might be due to `utils.py` utilizing `ffn_hidden_size` instead of `moe_ffn_hidden_size` when estimating expert parameters, which could potentially affect the accuracy of parameter counting.


---

2. Toggling `USE_GEMM` between `false` and `true` results in different expert parameter counts. This appears to stem from implementation differences where:
- Class `MLP` uses `moe_ffn_hidden_size` for experts
- Both `GroupMLP` and `Megablock` utilize `ffn_hidden_size`

Note : ) This observation is specifically based on the Qwen. The behavior may differ for other architectures like LLaMA or DeepSeek, which haven't been verified in this context.